### PR TITLE
Remove call to getStatusMessageWrapperClass from twig tempalte for no…

### DIFF
--- a/templates/misc/status-messages.html.twig
+++ b/templates/misc/status-messages.html.twig
@@ -27,7 +27,7 @@
 
 {% block messages %}
   {% for type, messages in message_list %}
-  <div class="alert alert-{{ getStatusMessageWrapperClass(type) }} col-12 mt-2">
+  <div class="alert alert- col-12 mt-2">
     <span class="alert-content">
       {% if messages|length > 1 %}
         <ul>


### PR DESCRIPTION
…w, untill we decide where to port that function to, coming from bhcc_helper module.