### PR TITLE
Change alert banner library to reference localgov_alert_banner

### DIFF
--- a/templates/misc/eck-entity--alert-banner.html.twig
+++ b/templates/misc/eck-entity--alert-banner.html.twig
@@ -21,7 +21,7 @@
  */
 #}
 
-{{ attach_library('bhcc_alert_banner/alert_banner') }}
+{{ attach_library('localgov_alert_banner/alert_banner') }}
 
 {# Possible values for alert_type: minor, major, notable-person #}
 {% set alert_type = eck_entity.get('field_alert_type_of_alert').value %}


### PR DESCRIPTION
Ref #32

To show the display of the alert banner with the theme correctly
Ref localgovdrupal/localgov_alert_banner#11