### PR TITLE
The "Skip to main content" link should remain at the top

### DIFF
--- a/assets/js/skip-link-relocation.es6.js
+++ b/assets/js/skip-link-relocation.es6.js
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * Move the skip-link to the top.
+ *
+ * Currently, the EU cookie compliance popup forces itself as the first child
+ * of the body tag.  But we want the "Skip to main content" link to remain as
+ * the first child.  Here we relocate the skip-link so that it remains the first
+ * child of the body element.  This helps screen reader users.
+ *
+ * @see localgov_theme/templates/system/html.html.twig
+ * @see Drupal.eu_cookie_compliance.createWithdrawBanner()
+ */
+
+(function moveSkipLinkToTop(Drupal) {
+  Drupal.behaviors.moveSkipLinkToTop = {
+    attach() {
+      const skipLink = document.querySelector("body > a.skip-link");
+      const hasNoSkipLink = !skipLink;
+      if (hasNoSkipLink) {
+        return;
+      }
+
+      const firstItem = document.querySelector("body > :first-child");
+      const isSkipLinkAtTheTop = firstItem === skipLink;
+      if (isSkipLinkAtTheTop) {
+        return;
+      }
+
+      // Move skip-link above the popup (or whatever is sitting there).
+      firstItem.parentNode.insertBefore(skipLink, firstItem);
+    }
+  };
+})(Drupal);

--- a/assets/js/skip-link-relocation.js
+++ b/assets/js/skip-link-relocation.js
@@ -1,0 +1,35 @@
+"use strict";
+
+/**
+ * @file
+ * Move the skip-link to the top.
+ *
+ * Currently, the EU cookie compliance popup forces itself as the first child
+ * of the body tag.  But we want the "Skip to main content" link to remain as
+ * the first child.  Here we relocate the skip-link so that it remains the first
+ * child of the body element.  This helps screen reader users.
+ *
+ * @see localgov_theme/templates/system/html.html.twig
+ * @see Drupal.eu_cookie_compliance.createWithdrawBanner()
+ */
+
+(function moveSkipLinkToTop(Drupal) {
+  Drupal.behaviors.moveSkipLinkToTop = {
+    attach: function attach() {
+      var skipLink = document.querySelector("body > a.skip-link");
+      var hasNoSkipLink = !skipLink;
+      if (hasNoSkipLink) {
+        return;
+      }
+
+      var firstItem = document.querySelector("body > :first-child");
+      var isSkipLinkAtTheTop = firstItem === skipLink;
+      if (isSkipLinkAtTheTop) {
+        return;
+      }
+
+      // Move skip-link above the popup (or whatever is sitting there).
+      firstItem.parentNode.insertBefore(skipLink, firstItem);
+    }
+  };
+})(Drupal);

--- a/localgov_theme.libraries.yml
+++ b/localgov_theme.libraries.yml
@@ -27,3 +27,10 @@ fontawesome:
       https://use.fontawesome.com/releases/v5.13.0/css/all.css:
         type: external
         minified: true
+
+# Move skip-link above EU cookie compliance popup.
+skip-link-relocation:
+  js:
+    assets/js/skip-link-relocation.js: {}
+  dependencies:
+    - eu_cookie_compliance/eu_cookie_compliance_bare

--- a/localgov_theme.theme
+++ b/localgov_theme.theme
@@ -33,6 +33,11 @@ function localgov_theme_preprocess_html(&$variables) {
       $variables['attributes']['class'][] = 'node--' . $node->bundle();
     }
   }
+
+  $has_eu_cookie_compliance_module = Drupal::service('module_handler')->moduleExists('eu_cookie_compliance');
+  if ($has_eu_cookie_compliance_module) {
+    $variables['#attached']['library'][] = 'localgov_theme/skip-link-relocation';
+  }
 }
 
 /**


### PR DESCRIPTION
The skip-link should be the first child of the body tag.  The EU cookie
compliance module's popup displaces the skip-link when told to appear at
the top of the page or be screen reader friendly.  Here we are attempting
to restore the skip-link's original position.