### PR TITLE
Determining if the sidebars are empty or not.

### DIFF
--- a/localgov_theme.theme
+++ b/localgov_theme.theme
@@ -54,6 +54,16 @@ function localgov_theme_preprocess_page(&$variables) {
   if (!$module_handler->moduleExists('fontawesome')) {
     $variables['#attached']['library'][] = 'localgov_theme/fontawesome';
   }
+
+  // Work around for Drupal core issue.
+  // Blocks employ lazy building.  This makes it difficult to determine from
+  // **Twig templates** if they will eventually produce empty content or not.
+  // @see https://www.drupal.org/node/953034
+  // @see https://www.drupal.org/forum/support/module-development-and-code-questions/2016-04-07/drupal-8-regions-with-and-empty#comment-12149518
+  $rendered_sidebar_first = Drupal::service('renderer')->renderPlain($variables['page']['sidebar_first']);
+  $rendered_sidebar_second = Drupal::service('renderer')->renderPlain($variables['page']['sidebar_second']);
+  $variables['has_sidebar_first'] = trim(strip_tags($rendered_sidebar_first));
+  $variables['has_sidebar_second'] = trim(strip_tags($rendered_sidebar_second));
 }
 
 /**

--- a/localgov_theme.theme
+++ b/localgov_theme.theme
@@ -60,8 +60,10 @@ function localgov_theme_preprocess_page(&$variables) {
   // **Twig templates** if they will eventually produce empty content or not.
   // @see https://www.drupal.org/node/953034
   // @see https://www.drupal.org/forum/support/module-development-and-code-questions/2016-04-07/drupal-8-regions-with-and-empty#comment-12149518
-  $rendered_sidebar_first = Drupal::service('renderer')->renderPlain($variables['page']['sidebar_first']);
-  $rendered_sidebar_second = Drupal::service('renderer')->renderPlain($variables['page']['sidebar_second']);
+  $sidebar_first_copy = $variables['page']['sidebar_first'];
+  $sidebar_second_copy = $variables['page']['sidebar_second'];
+  $rendered_sidebar_first = Drupal::service('renderer')->renderPlain($sidebar_first_copy);
+  $rendered_sidebar_second = Drupal::service('renderer')->renderPlain($sidebar_second_copy);
   $variables['has_sidebar_first'] = trim(strip_tags($rendered_sidebar_first));
   $variables['has_sidebar_second'] = trim(strip_tags($rendered_sidebar_second));
 }

--- a/templates/system/page.html.twig
+++ b/templates/system/page.html.twig
@@ -15,6 +15,8 @@
 * - logged_in: A flag indicating if the user is registered and signed in.
 * - is_admin: A flag indicating if the user has permission to access
 *   administration pages.
+* - has_sidebar_first: Can we expect any content in the first sidebar?
+* - has_sidebar_second: See above.
 *
 * Site identity:
 * - front_page: The URL of the front page. Use this instead of base_path when
@@ -50,8 +52,6 @@
 * @ingroup themeable
 */
 #}
-{% set has_sidebar_first = page.sidebar_first|render|striptags|trim is not empty %}
-{% set has_sidebar_second = page.sidebar_second|render|striptags|trim is not empty %}
 {%
   set content_classes = [
     has_sidebar_first and page.sidebar_second ? 'col-sm-6',


### PR DESCRIPTION
Work around for conditional display of theme region.

[Blocks](https://git.drupalcode.org/project/drupal/-/blob/9.0.x/core/modules/block/src/BlockViewBuilder.php#L76) employ [lazy building](https://www.drupal.org/docs/8/api/render-api/auto-placeholdering).  This makes it difficult to determine from **Twig templates** if they will eventually produce [empty content or not](https://github.com/localgovdrupal/localgov_theme/blob/231234f2cb87663dce89445a6a80edf059e4b6bc/templates/system/page.html.twig#L53).

To reproduce this, place any block with **entirely dynamic** content into the sidebar of the localgov_theme (any Views block should do).  It wouldn't show up in the sidebar :(

This work around attempts to get past this limitation by rendering a **copy** of the sidebars' render array in the page preprocess function.  If the rendered markup is nonempty, we can conclude that the sidebar has displayable content.

I am raising this pull request to explain the situation with the [Directory block ticket](https://github.com/localgovdrupal/localgov_directories/issues/30).