### PR TITLE
Updated Call out box template

### DIFF
--- a/localgov_theme.theme
+++ b/localgov_theme.theme
@@ -143,7 +143,7 @@ function localgov_theme_preprocess_paragraph(&$variables) {
   if ($paragraph->bundle() === 'localgov_call_out_box') {
     $image = $paragraph->get('localgov_background_image');
     if (!$image->isEmpty() && $image->entity) {
-      $variables['image_alt_text'] = $image->entity->field_media_image[0]->getValue()['alt'];
+      $variables['image_alt_text'] = $image->entity->field_media_image->first()->alt;
     }
   }
 }

--- a/localgov_theme.theme
+++ b/localgov_theme.theme
@@ -132,3 +132,18 @@ function localgov_theme_theme_suggestions_alter(array &$suggestions, array $vari
     $suggestions[] = 'field__clean';
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function localgov_theme_preprocess_paragraph(&$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+
+  if ($paragraph->bundle() === 'localgov_call_out_box') {
+    $image = $paragraph->get('localgov_background_image');
+    if (!$image->isEmpty() && $image->entity) {
+      $variables['image_alt_text'] = $image->entity->field_media_image[0]->getValue()['alt'];
+    }
+  }
+}

--- a/templates/paragraph/paragraph--localgov-call-out-box.html.twig
+++ b/templates/paragraph/paragraph--localgov-call-out-box.html.twig
@@ -1,16 +1,27 @@
+{%
+  set classes = [
+    'call-out-box',
+    colour_theme ? 'call-out-box--' ~ colour_theme|clean_class,
+    'row',
+    'mx-1'
+  ]
+%}
 
-<div class="call-out-box row mx-1">
-  <div class="col-12 col-md-6 order-md-2 p-0" />
-    {% if background_url is defined and background_url %}
-      <img src="{{ background_url }}" />
-    {% endif %}
-  </div>
+<div{{ attributes.addClass(classes) }}>
+  {% if background_url is defined and background_url %}
+    <div class="col-12 col-md-6 order-md-2 p-0">
+      <img src="{{ background_url }}" alt="{{ image_alt_text }}" />
+    </div>
+  {% endif %}
   <div class="col-12 col-md-6 order-md-1 p-4">
-    <h2>{{ content.localgov_header_text }}</h2>
+    {{ heading }}
     {{ content.localgov_body_text }}
-    <a href="{{ button_url }}" class="btn btn-primary">
+    <a href="{{ button_url }}" class="btn btn-primary"
+      {% if open_in_new_window %} target="_blank" {% endif %}>
       <span>{{ paragraph.localgov_button.getValue[0].title }}</span>
+      {% if open_in_new_window %}
+        <span class="visually-hidden"> {{ '(opens in a new window)'|t }}</span>
+      {% endif %}
     </a>
   </div>
 </div>
-


### PR DESCRIPTION
As new fields were added to the Call out box paragraph, the theme template needed updating.

I've also added `alt` attribute to the image element, as it no longer is a background image (as it is in the campaigns paragraphs module).