### PR TITLE
Add new stylesheet for CK editor iframes

### DIFF
--- a/assets/css/lib/ck_style.css
+++ b/assets/css/lib/ck_style.css
@@ -1,0 +1,2 @@
+
+/*# sourceMappingURL=ck_style.css.map */

--- a/assets/css/lib/ck_style.css.map
+++ b/assets/css/lib/ck_style.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":[],"names":[],"mappings":"","file":"ck_style.css","sourcesContent":[]}

--- a/assets/scss/lib/ck_style.scss
+++ b/assets/scss/lib/ck_style.scss
@@ -1,0 +1,17 @@
+/* Imports all styles needed to be included within the site's CK editor instances. */
+
+// Import council theme settings
+@import 'theme'; // replace with '_variables-REPLACEWITHYOURCOUNCILNAME'
+
+
+// Functions
+@import 'functions';
+
+
+// Import Bootstrap css
+// Required
+@import '../../../node_modules/bootstrap/scss/functions';
+@import '../../../node_modules/bootstrap/scss/mixins';
+@import '../../../node_modules/bootstrap/scss/variables';
+
+@import 'variables';

--- a/localgov_theme.info.yml
+++ b/localgov_theme.info.yml
@@ -8,6 +8,11 @@ base theme: localgov_skeleton
 libraries:
   - localgov_theme/global
 
+# Stylesheets specifically for CK editor iframes
+ckeditor_stylesheets:
+  - assets/css/font-face.css
+  - assets/css/lib/ck_style.css
+
 regions:
   header: "Header"
   search: "Search"


### PR DESCRIPTION
There is now a  ck_style.scss next to main that compiles to the same directory. I've included these in the theme.info file but currently the generated CSS is empty because it's only mixins and functions being pulled in.