### PR TITLE
Feature/automated theme tests

### DIFF
--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -59,9 +59,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm install
-        shell: bash
-        working-directory: client
+          working-directory: client
 
       - run: npm run health-check
-        shell: bash
-        working-directory: client
+          working-directory: client

--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -53,6 +53,7 @@ jobs:
         node-version: [ 10.x, 12.x, 14.x]
 
     steps:
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  DrupalUnitTests:
 
     runs-on: ubuntu-latest
 
@@ -43,3 +43,19 @@ jobs:
       - name: Run tests
         run: ./run-tests.sh
         shell: bash
+
+  MochaThemeTests:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [ 10.x, 12.x]
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run health-check

--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -59,9 +59,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm install
-          shell: bash
-          working-directory: client
+        shell: bash
+        working-directory: client
 
       - run: npm run health-check
-          shell: bash
-          working-directory: client
+        shell: bash
+        working-directory: client

--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -50,12 +50,18 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 10.x, 12.x]
+        node-version: [ 10.x, 12.x, 14.x]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - run: npm install
+          shell: bash
+          working-directory: client
+
       - run: npm run health-check
+          shell: bash
+          working-directory: client

--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -58,8 +58,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - run: npm install
-          working-directory: client
+      - name: Install Node dependencies
+        run: npm ci
 
       - run: npm run health-check
-          working-directory: client

--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -50,7 +50,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 10.x, 12.x, 14.x]
+        node-version: [10.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -60,6 +60,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install Node dependencies
-        run: npm ci
+        run: npm install
 
       - run: npm run health-check

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,8 +130,14 @@ const dev = gulp.series(
   gulp.parallel(browserSyncStart, watchStyle, serve)
 );
 
+/** Generates style without any listeners or browserSync */
+const generate = gulp.series(
+  generateStyle,
+);
+
 // Expose the task by exporting it, this allows you to run it from the commandline
 exports.dev = dev;
+exports.generate = generate;
 
 
 /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,6 +289,70 @@
         "through2": "^2.0.3"
       }
     },
+    "@jsdevtools/chai-exec": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/chai-exec/-/chai-exec-2.1.1.tgz",
+      "integrity": "sha512-EhLHKeucYbbbWHDhExi0fqDSI9noxYUdzy1LLaAdkHLaIJjd8gv5bCOqEsuVh6EJF3ZspUSpLJjytxnOPahRig==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ez-spawn": "^3.0.3"
+      }
+    },
+    "@jsdevtools/ez-spawn": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
+      "integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "cross-spawn": "^7.0.3",
+        "string-argv": "^0.3.1",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -418,6 +482,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
     "abbrev": {
@@ -794,6 +864,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -1431,6 +1507,12 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browser-sync": {
       "version": "2.26.7",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.7.tgz",
@@ -1656,6 +1738,12 @@
         }
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -1745,6 +1833,20 @@
       "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1789,6 +1891,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -2625,6 +2733,15 @@
         }
       }
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "default-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
@@ -2761,6 +2878,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "dir-glob": {
@@ -3784,6 +3907,12 @@
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
       "dev": true
     },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -3992,6 +4121,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-proxy": {
@@ -4358,6 +4493,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "growly": {
@@ -5307,6 +5448,12 @@
           }
         }
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "hex-color-regex": {
       "version": "1.1.0",
@@ -7190,6 +7337,303 @@
         }
       }
     },
+    "mocha": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.0.tgz",
+      "integrity": "sha512-lEWEMq2LMfNJMKeuEwb5UELi+OgFDollXaytR5ggQcHpzG3NP/R7rvixAvF+9/lLsTWhWG+4yD2M70GsM06nxw==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.4.3",
+        "debug": "4.2.0",
+        "diff": "4.0.2",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.14.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.2",
+        "nanoid": "3.1.12",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "7.2.0",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.0.2",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+          "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "mozjpeg": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/mozjpeg/-/mozjpeg-6.0.1.tgz",
@@ -7227,6 +7671,12 @@
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
       "dev": true
     },
     "nanomatch": {
@@ -8072,6 +8522,12 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -8959,6 +9415,15 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9563,6 +10028,15 @@
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
+      }
+    },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "serve-index": {
@@ -10280,6 +10754,12 @@
       "dev": true,
       "optional": true
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -10387,6 +10867,12 @@
       "requires": {
         "get-stdin": "^4.0.1"
       }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
     },
     "strip-outer": {
       "version": "1.0.1",
@@ -11509,6 +11995,12 @@
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -12051,6 +12543,12 @@
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
       "dev": true
     },
+    "workerpool": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+      "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -12294,6 +12792,38 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+          "integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
   "scripts": {
     "build": "NODE_ENV=production gulp dev",
     "dev": "NODE_ENV=development gulp dev",
-    "health-check": "mocha --file=tests/health-check.js",
-    "test": "echo \"\nTry running yarn health-check or yarn postinstall to run automated tests.\n\" && exit 0",
-    "postinstall": "mocha --file=tests/health-check.js",
+    "health-check": "mocha --file=tests/health-check.test.js",
+    "test": "mocha --file=tests/health-check.test.js",
     "generate": "NODE_ENV=production gulp generate"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "NODE_ENV=development gulp dev",
     "health-check": "mocha --file=tests/health-check.js",
     "test": "echo \"\nTry running yarn health-check or yarn postinstall to run automated tests.\n\" && exit 0",
-    "postinstall": "mocha --file=tests/health-check.js"
+    "postinstall": "mocha --file=tests/health-check.js",
+    "generate": "NODE_ENV=production gulp generate"
   },
   "author": "",
   "license": "GPL-2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   },
   "scripts": {
     "build": "NODE_ENV=production gulp dev",
-    "dev": "NODE_ENV=development gulp dev"
+    "dev": "NODE_ENV=development gulp dev",
+    "health-check": "mocha --file=tests/health-check.js",
+    "test": "echo \"\nTry running yarn health-check or yarn postinstall to run automated tests.\n\" && exit 0",
+    "postinstall": "mocha --file=tests/health-check.js"
   },
   "author": "",
   "license": "GPL-2.0",
@@ -22,7 +25,9 @@
     "> 2%"
   ],
   "devDependencies": {
+    "@jsdevtools/chai-exec": "^2.1.1",
     "browser-sync": "^2.26.7",
+    "chai": "^4.2.0",
     "cssnano": "^4.1.10",
     "del": "^4.1.1",
     "gulp": "^4.0.2",
@@ -41,6 +46,7 @@
     "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^3.0.2",
     "gulp-version-append": "^0.2.0",
+    "mocha": "^8.2.0",
     "npm-install-all": "^1.1.21",
     "postcss-reporter": "^6.0.1",
     "postcss-scss": "^2.1.1",

--- a/tests/health-check.js
+++ b/tests/health-check.js
@@ -2,11 +2,12 @@
 
 const chai = require('chai'),
       chaiExec = require("@jsdevtools/chai-exec"), // Allows us to assert CLI commands
-      assert = chai.assert;
+      assert = chai.assert,
+      expect = chai.expect;
 const fs = require('fs'), // Node file system
       { exec } = require("child_process"); // Node exec function that allows us to run other commands
 
-
+// Register @jsdevtools/chai-exec
 chai.use(chaiExec);
 
 /* Returns true or false depending if a directory exists or not */
@@ -128,16 +129,12 @@ describe('Health check: General theme structure', function () {
 
 describe('Health check: Gulp tasks', function () {
   describe('Testing NPM commands ', function () {
-    it('\'npm run dev\'', function(done) {
-      assert(exec('npm run dev'))
-      done()
-    });
+    it('\'npm run generate\'', function(done) {
+      this.timeout(15000);
+      let npm = chaiExec('npm run generate');
 
-    it('\'npm run build\'', function(done) {
-      let npm = chaiExec('npm run dev');
-
-      assert.stdout(npm, 'Finished \'generateStyle\'');
-      assert.notExitCode(npm, 1);
+      expect(npm).to.have.output.that.contains('Finished \'generateStyle\'');
+      assert.exitCode(npm, 0);
       done()
     });
   });

--- a/tests/health-check.js
+++ b/tests/health-check.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const chai = require('chai'),
+      chaiExec = require("@jsdevtools/chai-exec"), // Allows us to assert CLI commands
+      assert = chai.assert;
+const fs = require('fs'), // Node file system
+      { exec } = require("child_process"); // Node exec function that allows us to run other commands
+
+
+chai.use(chaiExec);
+
+/* Returns true or false depending if a directory exists or not */
+function checkDirectoryExists(directory) {
+  try {
+    if (fs.existsSync(directory)) {
+      return true
+    }
+  } catch(err) {
+    return false
+  }
+}
+
+/* Alias for checkDirectoryExists() so that code is more readable */
+function checkFileExists(file) {
+  return checkDirectoryExists(file)
+}
+
+/* Returns true if a file contains string */
+function fileContains(file, text) {
+  try {
+    const data = fs.readFileSync(file, {encoding: 'utf8'})
+    if(data.includes(text)) {
+      return true
+    } else {
+      return false
+    }
+  } catch (error) {
+    return false
+  }
+}
+
+
+describe('Health check: General theme structure', function () {
+  describe('Directory structure', function () {
+    it('./assets', function(done) {
+      assert(checkDirectoryExists('./assets'))
+      done()
+    });
+    it('./assets/css', function(done) {
+      assert(checkDirectoryExists('./assets/css'))
+      done()
+    });
+    it('./assets/js', function(done) {
+      assert(checkDirectoryExists('./assets/js'))
+      done()
+    });
+    it('./templates', function(done) {
+      assert(checkDirectoryExists('./templates'))
+      done()
+    });
+  });
+
+  describe('Checking compiled files exist', function () {
+    it('./assets/css/lib/style.css', function(done) {
+      assert(checkFileExists('./assets/css/lib/main.css'))
+      done()
+    });
+    it('./assets/js/main.js', function(done) {
+      assert(checkFileExists('./assets/js/main.js'))
+      done()
+    });
+  });
+
+  describe('Verifying source control and metadata', function () {
+    it('.gitignore exists', function(done) {
+      assert(checkFileExists('./.gitignore'))
+      done()
+    });
+    it('node_modules/ is gitignored', function(done) {
+      assert(fileContains('./.gitignore', 'node_modules'));
+      done()
+    });
+    it('composer.json', function(done) {
+      assert(checkFileExists('./composer.json'))
+      done()
+    });
+    it('LICENSE', function(done) {
+      assert(checkFileExists('./LICENSE'))
+      done()
+    });
+    it('package.json', function(done) {
+      assert(checkFileExists('./package.json'))
+      done()
+    });
+    it('README.md', function(done) {
+      assert(checkFileExists('./README.md'))
+      done()
+    });
+  });
+
+  describe('Verifying Drupal files', function () {
+    it('breakpoints.yml', function(done) {
+      assert(checkFileExists('./localgov_theme.breakpoints.yml'))
+      done()
+    });
+    it('info.yml', function(done) {
+      assert(checkFileExists('./localgov_theme.info.yml'))
+      done()
+    });
+    it('libraries.yml', function(done) {
+      assert(checkFileExists('./localgov_theme.libraries.yml'))
+      done()
+    });
+    it('theme PHP file', function(done) {
+      assert(checkFileExists('./localgov_theme.theme'))
+      done()
+    });
+  });
+
+  describe('Making sure config files exist', function () {
+    it('.stylelintrc', function(done) {
+      assert(checkFileExists('./.stylelintrc'))
+      done()
+    });
+  });
+});
+
+
+describe('Health check: Gulp tasks', function () {
+  describe('Testing NPM commands ', function () {
+    it('\'npm run dev\'', function(done) {
+      assert(exec('npm run dev'))
+      done()
+    });
+
+    it('\'npm run build\'', function(done) {
+      let npm = chaiExec('npm run dev');
+
+      assert.stdout(npm, 'Finished \'generateStyle\'');
+      assert.notExitCode(npm, 1);
+      done()
+    });
+  });
+});

--- a/tests/health-check.test.js
+++ b/tests/health-check.test.js
@@ -147,7 +147,7 @@ describe('Health check: Gulp tasks', function () {
   describe('Testing NPM commands ', function () {
     this.timeout(15000);
 
-    it('\'npm run generate\'', function(done) {
+    it(`${npmGenerate}`, function(done) {
       let npm = chaiExec(npmGenerate);
 
       expect(npm).to.have.output.that.contains('Finished \'generateStyle\'');
@@ -160,23 +160,24 @@ describe('Health check: Gulp tasks', function () {
 
     it('Creating a new SCSS file and compiling it', function(done) {
       this.timeout(20000);
-      fs.writeFile(scssFile, mochaScssString, function(err) {
-        return err ? console.log(err) : null;
+      fs.writeFile(scssFile, mochaScssString, function(error) {
+        if (error) {
+          return error;
+        } else {
+          try {
+            exec(npmGenerate, (err) => {
+              if(err) {return; }
+            });
+            //assert(checkFileExists(cssFile));
+            done();
+          }
+          catch(e) {
+            done(e);
+          }
+        }
       });
 
-      try {
-        exec(npmGenerate, (err) => {
-          if (err) {
-            return;
-          }
-        });
 
-        assert(checkFileExists(cssFile));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
       //done();
     });
 

--- a/tests/health-check.test.js
+++ b/tests/health-check.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
       assert = chai.assert,
       expect = chai.expect;
 const fs = require('fs'), // Node file system
-      { exec, execSync } = require("child_process"); // Node exec function that allows us to run other commands
+      { execSync } = require("child_process"); // Node exec function that allows us to run other commands
 
 // Register @jsdevtools/chai-exec
 chai.use(chaiExec);
@@ -45,6 +45,11 @@ function writeToFile(file, text) {
 /* Runs a command synchronously using execSync */
 function runCommand(command) {
   execSync(command);
+}
+
+/* Removes a file using fs.unlinkSync */
+function removeFile(file) {
+  fs.unlinkSync(file);
 }
 
 
@@ -197,9 +202,9 @@ describe('Health check: Gulp tasks', function () {
     });
 
     after(function() {
-      fs.unlinkSync(scssFile);
-      fs.unlinkSync(cssFile);
-      fs.unlinkSync(cssMapFile);
+      removeFile(scssFile);
+      removeFile(cssFile);
+      removeFile(cssMapFile);
     });
   });
 });

--- a/tests/health-check.test.js
+++ b/tests/health-check.test.js
@@ -13,9 +13,7 @@ chai.use(chaiExec);
 /* Returns true or false depending if a directory exists or not */
 function checkDirectoryExists(directory) {
   try {
-    if (fs.existsSync(directory)) {
-      return true
-    }
+    return fs.existsSync(directory)
   } catch(err) {
     return false
   }
@@ -29,12 +27,7 @@ function checkFileExists(file) {
 /* Returns true if a file contains string */
 function fileContains(file, text) {
   try {
-    const data = fs.readFileSync(file, {encoding: 'utf8'})
-    if(data.includes(text)) {
-      return true
-    } else {
-      return false
-    }
+    return fs.readFileSync(file, {encoding: 'utf8'}).includes(text)
   } catch (error) {
     return false
   }
@@ -49,7 +42,7 @@ function writeToFile(file, text) {
   });
 }
 
-
+/* Runs a command synchronously using execSync */
 function runCommand(command) {
   execSync(command);
 }


### PR DESCRIPTION
What this PR does:

* Renames existing tests to DrupalUnitTests so it's more descriptive under the checks tab

* Adds new theme tests that are run using Mocha.js testing for compilation

* Creates a new command for gulp and npm for generating files without any watchers (for now) and for testing. `npm test` will run some default tests checking that the theme structure is all good and compilation works

It currently tests only on Node 10.x but we can extend that for other node versions. You can view the [output here](https://github.com/localgovdrupal/localgov_theme/pull/107/checks?check_run_id=1287809075).

Tests sit in `tests/health-check.test.js`

Full output of `npm test` or `npm run health-check`

```bash
> localgov_theme@1.0.0 health-check /app
> mocha --file=tests/health-check.test.js

Warning: Cannot find any files matching pattern "test"


  Health check: General theme structure
    Directory structure
      ✓ ./assets
      ✓ ./assets/css
      ✓ ./assets/js
      ✓ ./templates
    Checking compiled files exist
      ✓ ./assets/css/lib/style.css
      ✓ ./assets/js/main.js
    Verifying source control and metadata
      ✓ .gitignore exists
      ✓ node_modules/ is gitignored
      ✓ composer.json
      ✓ LICENSE
      ✓ package.json
      ✓ README.md
    Verifying Drupal files
      ✓ breakpoints.yml
      ✓ info.yml
      ✓ libraries.yml
      ✓ theme PHP file
    Making sure config files exist
      ✓ .stylelintrc

  Health check: Gulp tasks
    Testing NPM commands 
      ✓ npm run generate (5535ms)
    Testing SCSS file compilation 
      ✓ Creating a new SCSS file
Browserslist: caniuse-lite is outdated. Please run next command `npm update`
      ✓ Compile SCSS to CSS (5545ms)
      ✓ New CSS file exists with correct selectors
      ✓ CSS map file exists


  22 passing (11s)
```