### PR TITLE
cta block and alert button styling

### DIFF
--- a/assets/scss/lib/_variables.scss
+++ b/assets/scss/lib/_variables.scss
@@ -186,6 +186,10 @@ $button-icons: $yellow;
 $button-text-hover: $white;
 $button-text-focus: $white;
 
+$alert-button-color: $white;
+$alert-button-hover: $carbon;
+$alert-button-background: transparent;
+
 $link-button: $primary;
 $link-button-text: $white;
 $link-button-text-focus: $carbon;

--- a/assets/scss/lib/partials/_alert.scss
+++ b/assets/scss/lib/partials/_alert.scss
@@ -119,3 +119,34 @@
     content: $alert-warning;
   }
 }
+
+.localgov_alert_banner {
+  button { // default form button styling
+    background-color: $alert-button-background;
+    color: $alert-button-color;
+    border-radius: 0;
+    padding: .5rem .9375rem;
+    line-height: 1.5;
+    border: 1px solid $alert-button-color;
+    text-align: center;
+    vertical-align: middle;
+    font-weight: 700;
+
+    &:focus,
+    &:hover {
+      color: $alert-button-hover;
+      border: 1px solid $alert-button-hover;
+    }
+  }
+
+  .localgov_alert_banner--dismiss
+    a { // alternative styling for link button
+      color: $alert-button-color;
+
+      &:hover,
+      &:focus {
+      background: $alert-button-color;
+      color: $alert-button-hover;
+    }
+  }
+}

--- a/assets/scss/lib/partials/_buttons.scss
+++ b/assets/scss/lib/partials/_buttons.scss
@@ -70,6 +70,12 @@ aside .btn .fa,
     @include outline(.1875rem, -.1875rem, $focus);
   }
 
+  &:not(:disabled):not(.disabled).active {
+    &:focus {
+      box-shadow: none; // bs override
+    }
+  }
+
   &.btn-secondary {
     background: $secondary;
     color: $white;

--- a/templates/block/services-cta-block.html.twig
+++ b/templates/block/services-cta-block.html.twig
@@ -28,9 +28,9 @@
 
 {% block content %}
 <nav aria-label="Section Navigation">
-  <div class="row mt-sm-3 mb-sm-3 pt-2 pb-3">
+  <div class="row mt-sm-3 mb-sm-3">
   {% for button in buttons %}
-    <div class="mb-4 col-sm-4">
+    <div class="mb-3 col-sm-4">
       <a href="{{ button.url }}" class="link-button {{ button.type }}">
         <span>{{ button.title }}</span>
       </a>


### PR DESCRIPTION
- Tightening up the CTA display for service pages
- Add Button and fallback link as a button styling for alert banner buttons