### PR TITLE
disable font face css aggregation which causes font rendering issues …

### DIFF
--- a/localgov_theme.libraries.yml
+++ b/localgov_theme.libraries.yml
@@ -4,7 +4,7 @@ global:
       https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700,700i:
         type: external
     theme:
-      assets/css/font-face.css: {}
+      assets/css/font-face.css: {preprocess: false}
       assets/css/lib/main.css: {}
   js:
     assets/js/bootstrap.min.js: {}


### PR DESCRIPTION
…when the site is deployed

We recently identified a problem on Croydon with custom fonts not working once the site is deployed. This was fixed by disabling css aggregation on font-face.css - this change should be replicated back to the base theme ... more info here: localgovdrupal/localgov_theme_croydon#17

for issue: #136 