### PR TITLE
Bug fix for page template suggestion

### DIFF
--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
       - name: Clone drupal_container
         uses: actions/checkout@v2
         with:

--- a/localgov_theme.theme
+++ b/localgov_theme.theme
@@ -85,7 +85,10 @@ function localgov_theme_preprocess_field(&$variables) {
 function localgov_theme_preprocess_menu(&$variables) {
   // Add classes to the relevant menu.
   if ($variables['menu_name'] === 'main') {
-    $variables['attributes']['class'] = ['services-list', 'services-list--multi'];
+    $variables['attributes']['class'] = [
+      'services-list',
+      'services-list--multi',
+    ];
   }
 
   if ($variables['menu_name'] === 'business') {
@@ -135,7 +138,19 @@ function localgov_theme_preprocess_office_hours(&$variables) {
 function localgov_theme_theme_suggestions_alter(array &$suggestions, array $variables, $hook) {
   // Allow page template to be overridden by content type.
   if ($hook == 'page' && $node = \Drupal::routeMatch()->getParameter('node')) {
-    $suggestions[] = 'page__' . $node->bundle();
+    // For the frontpage, ensure that *page__front* is always the final
+    // suggestion.
+    $is_front_page = end($suggestions) === 'page__front';
+    if ($is_front_page) {
+      $front_page_tpl_suggestion_key = key($suggestions);
+      unset($suggestions[$front_page_tpl_suggestion_key]);
+
+      $suggestions[] = 'page__' . $node->bundle();
+      $suggestions[] = 'page__front';
+    }
+    else {
+      $suggestions[] = 'page__' . $node->bundle();
+    }
   }
   // Fields to be rendered through the field--clean.html.twig template.
   $clean_fields = [


### PR DESCRIPTION
For node pages, the current suggestion is adding a content type specific
template suggestion as the final one.  This overrides Drupal's front-page
specific template suggestion making it impossible to have a frontpage
specific page template.

This change addresses this by restoring the frontpage specific template
suggestion to the final position.