### PR TITLE
Feature/146 skip main

### DIFF
--- a/templates/system/html.html.twig
+++ b/templates/system/html.html.twig
@@ -56,10 +56,12 @@
     Keyboard navigation/accessibility link to main content section in
     page.html.twig.
     #}
-    <a href="#main-content" class="visually-hidden focusable skip-link">
-      <i class="fas fa-fast-forward" aria-hidden="true"></i>
-      {{ 'Skip to main content'|t }}
-    </a>
+    <nav aria-label="Skip to Main Content">
+        <a href="#main-content" class="visually-hidden focusable skip-link">
+          <i class="fas fa-fast-forward" aria-hidden="true"></i>
+          {{ 'Skip to main content'|t }}
+        </a>
+    </nav>
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}

--- a/templates/system/html.html.twig
+++ b/templates/system/html.html.twig
@@ -57,10 +57,10 @@
     page.html.twig.
     #}
     <nav aria-label="Skip to Main Content">
-        <a href="#main-content" class="visually-hidden focusable skip-link">
-          <i class="fas fa-fast-forward" aria-hidden="true"></i>
-          {{ 'Skip to main content'|t }}
-        </a>
+      <a href="#main-content" class="visually-hidden focusable skip-link">
+        <i class="fas fa-fast-forward" aria-hidden="true"></i>
+        {{ 'Skip to main content'|t }}
+      </a>
     </nav>
     {{ page_top }}
     {{ page }}


### PR DESCRIPTION
During a recent accessibility review on Croydon via the AXE auditor - it was flagged that the 'Skip to Main' link should be contained within a landmark.

I have wrapped the link in a `<nav>` landmark and denoted its function with an 'aria-label'.

I've checked this from a visual and functional pov and all is well.