### PR TITLE
Bug fix: Avoid duplicate field id

### DIFF
--- a/localgov_theme.theme
+++ b/localgov_theme.theme
@@ -5,6 +5,7 @@
  * LocalGovDrupal theme file.
  */
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Template\Attribute;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -74,9 +75,11 @@ function localgov_theme_preprocess_page(&$variables) {
 
 /**
  * Implements hook_preprocess_HOOK().
+ *
+ * - Adds an Id attribute based on the fieldname.
  */
 function localgov_theme_preprocess_field(&$variables) {
-  $variables['attributes']['id'] = 'field--' . $variables['field_name'];
+  $variables['attributes']['id'] = Html::getUniqueId('field--' . $variables['field_name']);
 }
 
 /**


### PR DESCRIPTION
At the moment, we are preparing the field Id value, used in field templates,
from its fieldname.  This means *multiple* use of a particular field results in
duplicate Ids in the markup.  This is invalid.  To resolve this, we need to
ensure that field Ids are [unique](https://git.drupalcode.org/project/drupal/-/blob/9.2.x/core/lib/Drupal/Component/Utility/Html.php#L171).