### PR TITLE
Split the mocha tests into a separate file and update the drupal ci to the latest from upstream repo

### DIFF
--- a/.github/workflows/localgov-drupal-ci.yml
+++ b/.github/workflows/localgov-drupal-ci.yml
@@ -1,14 +1,14 @@
-name: Test LocalGov Drupal
+name: Execute Drupal's run-tests.sh for this branch
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-  DrupalUnitTests:
-
+  test:
+    name: 'Execute run-tests.sh'
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +17,7 @@ jobs:
         with:
           php-version: '7.4'
 
-      - name: Clone drupal_container
+      - name: Clone drupal-container
         uses: actions/checkout@v2
         with:
           repository: localgovdrupal/drupal-container
@@ -26,21 +26,22 @@ jobs:
       - name: Create LocalGov Drupal project
         run: composer create-project --stability dev localgovdrupal/localgov-project html
 
-      - name: Setup package source for the test target
-        run: |
-          composer --working-dir=html config repositories.1 vcs git@github.com:${{ github.repository }}.git
-          composer global config github-oauth.github.com ${{ github.token }}
-
-      - name: Extract Git branch name outside of a pull request
+      - name: Save git branch and git repo names to env if not a pull request
         if: github.event_name != 'pull_request'
-        run: echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-
-      - name: Extract Git branch name from a pull request
+        run: |
+          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+      - name: Save git branch and git repo names to env if is a pull request
         if: github.event_name == 'pull_request'
-        run: echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
-
-      - name: Grab test target
-        run: composer --working-dir=html require ${{ github.repository }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
+        run: |
+          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+      - name: Setup package source and authentication for the test target
+        run: |
+          composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
+          composer global config github-oauth.github.com ${{ github.token }}
+      - name: Grab test target from this repo
+        run: composer --working-dir=html require localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
 
       - name: Start Docker environment
         run: docker-compose up -d
@@ -48,23 +49,3 @@ jobs:
       - name: Run tests
         run: ./run-tests.sh
         shell: bash
-
-  MochaThemeTests:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [10.x]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install Node dependencies
-        run: npm install
-
-      - run: npm run health-check

--- a/.github/workflows/localgov-theme-ci.yml
+++ b/.github/workflows/localgov-theme-ci.yml
@@ -1,0 +1,28 @@
+name: Execute Mocha tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  MochaThemeTests:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Node dependencies
+        run: npm install
+
+      - run: npm run health-check


### PR DESCRIPTION
Closes https://github.com/localgovdrupal/localgov_theme/issues/154

The result of this is that updating either of these files should be easy as it's all separated and the [actions tab](https://github.com/localgovdrupal/localgov_theme/actions) has an extra test for every PR and a new tab to filter out specific workflows.