### PR TITLE
Add class for bootstrap component in drupal status messages

### DIFF
--- a/templates/misc/status-messages.html.twig
+++ b/templates/misc/status-messages.html.twig
@@ -27,7 +27,8 @@
 
 {% block messages %}
   {% for type, messages in message_list %}
-  <div class="alert alert- col-12 mt-2">
+  {% if type == 'status' %} {% set alertType = 'info' %} {% else %} {% set alertType = type %} {% endif %}
+  <div class="alert alert-{{ alertType }} col-12 mt-2">
     <span class="alert-content">
       {% if messages|length > 1 %}
         <ul>


### PR DESCRIPTION
Closes #135 

Adds the class for bootstrap components to the status message template so it looks a bit more obvious

![Screenshot from 2021-03-08 15-23-38](https://user-images.githubusercontent.com/35137243/110341705-8a273200-8022-11eb-9cf5-181f0e006ea7.png)