### PR TITLE
Add nav-link hover styling with accessible contrast

### DIFF
--- a/assets/scss/lib/partials/_nav.scss
+++ b/assets/scss/lib/partials/_nav.scss
@@ -43,6 +43,16 @@
   }
 }
 
+.navbar-dark .navbar-nav {
+  .nav-item {
+    .nav-link {
+      &:hover,
+      &:focus {
+        color: $secondary;
+      }
+    }
+  }
+}
 
 // Navbar dropdown menu
 .navbar-dark .navbar-nav,


### PR DESCRIPTION
Fixes #134 

This adds class selector with the right specificity so hover and focus states are accessible.

![Screenshot from 2021-03-08 16-47-45](https://user-images.githubusercontent.com/35137243/110353031-813c5d80-802e-11eb-8d0c-22241055b7c5.png)

Please note there's a [compilation](https://github.com/localgovdrupal/localgov_theme/issues/162) issue right now if you end up testing this PR.