### PR TITLE
Correctly provide string for bootstrap value override

### DIFF
--- a/assets/scss/lib/_variables.scss
+++ b/assets/scss/lib/_variables.scss
@@ -224,7 +224,7 @@ $navbar-dark-color: $white;
 $navbar-dark-hover-color: $yellow;
 $navbar-dark-active-color: $gray;
 $navbar-dark-disabled-color: rgba($white, .8);
-$navbar-dark-toggler-icon-bg: $gray;
+$navbar-dark-toggler-icon-bg: #{$gray};
 $navbar-dark-toggler-border-color: $white;
 
 // Remove breadcrumb bottom margin
@@ -310,7 +310,7 @@ $fa-share: '\f064';
 $fa-play: '\f04b';
 $fa-youtube-square: '\f431';
 $fa-search: '\f002';
-$fa-info-circle: '\f05a'; 
+$fa-info-circle: '\f05a';
 $fa-plus: '\f067';
 $fa-minus: '\f068';
 $fa-arrow-up: '\f30c';

--- a/tests/health-check.test.js
+++ b/tests/health-check.test.js
@@ -163,6 +163,8 @@ describe('Health check: Gulp tasks', function () {
       let npm = chaiExec(npmGenerate);
 
       expect(npm).to.have.output.that.contains('Finished \'generateStyle\'');
+      // Correctly check for errors on the output
+      expect(npm).to.not.have.output.that.contains('Error');
       assert.exitCode(npm, 0);
       done()
     });


### PR DESCRIPTION
Fixes #162 
I've added a check for errors so that we can catch compilation errors in these tests. They were getting returned but not handled correctly.