### PR TITLE
Feature/169 news styling

### DIFF
--- a/assets/scss/lib/main.scss
+++ b/assets/scss/lib/main.scss
@@ -76,6 +76,7 @@
 @import 'partials/map-overlay';
 @import 'partials/modal';
 @import 'partials/nav';
+@import 'partials/news';
 @import 'partials/notice';
 @import 'partials/page-builder';
 @import 'partials/search';

--- a/assets/scss/lib/partials/_base.scss
+++ b/assets/scss/lib/partials/_base.scss
@@ -207,6 +207,12 @@ mark {
   color: $success;
 }
 
+blockquote {
+  background-color: $gray-tint;
+  border-left: 0.3125rem solid $primary;
+  padding: 1.875rem;
+}
+
 // Icon padding right page and sidebars
 main .fa,
 main li .fa,

--- a/assets/scss/lib/partials/_facets.scss
+++ b/assets/scss/lib/partials/_facets.scss
@@ -67,73 +67,78 @@ h2.facet-filter-header {
 .facet-filter-checkboxes {
   list-style: none;
   font-size: $font-size-med;
-  background-color: $white;
+  background-color: transparent;
 
   @include rem(padding, 0, 12);
-}
 
-.facet-filter-checkboxes li {
-  border-bottom: 0.063rem solid $indigo-tint;
-  position: relative;
+  label {
+    display: inline-block;
+    max-width: 100%;
+    font-weight: $font-bold;
+    font-size: $font-size-lg;
 
-  @include rem(padding-top, 5);
-}
+    @include rem(padding-left, 30);
+    @include rem(margin-bottom, 5);
 
-.facet-filter-checkboxes li:last-child {
-  border-bottom: 0;
-}
+    &::before {
+      background-color: $white;
+      border: 0.063rem solid $indigo-tint;
+      content: '';
+      display: inline-block;
+      font-family: $font-family-icons;
+      font-size: $font-size-sm;
+      font-style: normal;
+      font-variant: normal;
+      left: 0;
+      margin-left: 0.25rem;
+      position: absolute;
+      text-align: center;
+      text-rendering: auto;
+      -webkit-font-smoothing: antialiased;
 
-.facet-filter-checkboxes label {
-  display: inline-block;
-  max-width: 100%;
-  font-weight: $font-bold;
-  font-size: $font-size-lg;
+      @include rem(width, 18);
+      @include rem(height, 18);
+      @include rem(line-height, 21);
+      @include rem(top, 10);    }
 
-  @include rem(padding-left, 30);
-  @include rem(margin-bottom, 5);
-}
+    span {
+      display: inline;
+    }
+  }
 
-.facet-filter-checkboxes label:before {
-  content: '';
-  border: 0.063rem solid $indigo-tint;
-  position: absolute;
-  left: 0;
-  font-family: $font-family-icons;
-  -webkit-font-smoothing: antialiased;
-  display: inline-block;
-  font-style: normal;
-  font-variant: normal;
-  text-rendering: auto;
-  text-align: center;
-  font-size: $font-size-sm;
+  input[type=checkbox] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0;
 
-  @include rem(width, 18);
-  @include rem(height, 18);
-  @include rem(line-height, 21);
-  @include rem(top, 10);
-}
+    @include rem(width, 20);
+    @include rem(height, 20);
 
-.facet-filter-checkboxes input[type=checkbox] {
-  position: absolute;
-  top: 0;
-  left: 0;
-  opacity: 0;
+    &:checked ~ label:before {
+      content: $fa-check;
+      border: 0.063rem solid $green;
+      color: $green;
+      display: block;
+      position: absolute;
+      left: 0;
 
-  @include rem(width, 20);
-  @include rem(height, 20);
-}
+      @include rem(width, 20);
+      @include rem(height, 20);
+      @include rem(top, 10);
+    }
+  }
 
-.facet-filter-checkboxes input[type=checkbox]:checked ~ label:before {
-  content: $fa-check;
-  border: 0.063rem solid $green;
-  color: $green;
-  display: block;
-  position: absolute;
-  left: 0;
+  li {
+    border-bottom: 0.063rem solid $indigo-tint;
+    position: relative;
 
-  @include rem(width, 20);
-  @include rem(height, 20);
-  @include rem(top, 10);
+    @include rem(padding-top, 5);
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
 }
 
 .directories-hide-filters {
@@ -178,7 +183,6 @@ h2.facet-filter-header {
   display: block;
 }
 
-
 .facets-widget-checkbox {
   > ul {
     list-style-type: none;
@@ -191,4 +195,18 @@ h2.facet-filter-header {
       padding: 0;
     }
   }
+}
+
+.block-facets {
+  background-color: $gray-tint;
+  padding: 1rem;
+}
+
+.facet-item label:hover {
+  cursor: pointer;
+}
+
+.facet-item input:focus + label,
+.facet-item input:hover + label {
+  background-color: $focus;
 }

--- a/assets/scss/lib/partials/_news.scss
+++ b/assets/scss/lib/partials/_news.scss
@@ -1,0 +1,111 @@
+.localgov-featured-news {
+  grid-column-gap: 2rem;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+
+  @include media-breakpoint-up(sm) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @include media-breakpoint-up(lg) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  article {
+    img {
+      margin-bottom: 0.5rem;
+    }
+
+    a {
+      color: $primary;
+      display: block;
+      text-decoration: none;
+    }
+
+    p {
+      display: none;
+    }
+
+    .localgov_news_date {
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
+  }
+}
+
+.block-localgov-news-feed,
+.view-localgov-news-search {
+  article {
+    border-bottom: 0.063rem solid $gray-primary;
+    display: flex;
+    flex-wrap: wrap;
+    margin-bottom: 1.5625rem;
+    padding-bottom: 1.5625rem;
+
+    @include media-breakpoint-up(lg) {
+      flex-direction: row-reverse;
+      flex-wrap: nowrap;
+    }
+
+
+    a {
+      display: block;
+      text-decoration: none;
+    }
+
+    .node__content {
+      flex-grow: 1;
+    }
+
+    img {
+      margin-bottom: 1rem;
+
+      @include media-breakpoint-up(lg) {
+        max-width: 16rem;
+        width: 16rem;
+      }
+    }
+
+    .localgov_news_date {
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
+  }
+
+  h3 {
+    font-size: 1.5rem;
+    letter-spacing: -0.025rem;
+    line-height: 2rem;
+    margin-top: 0;
+  }
+}
+
+.node--localgov_newsroom,
+.view-localgov-news-search {
+  article > a {
+    &:hover,
+    &:focus {
+      background-color: transparent;
+      box-shadow: none;
+    }
+  }
+}
+
+.newsroom--article {
+  h1 {
+    font-size: 2.25rem;
+    line-height: 2.5rem;
+  }
+
+  .newsroom--info {
+    margin-top: -.3125rem;
+    margin-bottom: 1.25rem;
+
+    .newsroom--category::before {
+      content: "  /  ";
+    }
+
+    a {
+      text-decoration: none;
+    }
+  }
+}

--- a/assets/scss/lib/partials/_news.scss
+++ b/assets/scss/lib/partials/_news.scss
@@ -33,6 +33,7 @@
 }
 
 .block-localgov-news-feed,
+.related-news,
 .view-localgov-news-search {
   article {
     border-bottom: 0.063rem solid $gray-primary;
@@ -80,6 +81,7 @@
 }
 
 .node--localgov_newsroom,
+.related-news,
 .view-localgov-news-search {
   article > a {
     &:hover,

--- a/templates/field/field--localgov-news-related.html.twig
+++ b/templates/field/field--localgov-news-related.html.twig
@@ -1,0 +1,6 @@
+<div class="related-news">
+  <h2>Related news</h2>
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+</div>


### PR DESCRIPTION
This PR closes #169:

- Adds styling for newsroom, news articles, and news teasers
- Amends styling for facets - no impact on styling of existing modules already using facets, the main change is to use transparent backgrounds for labels
- Adds a field template for related news
- Adds `blockquote` element styling to `_base.scss` - there is already classed styling of blockquotes in `_page-builder.scss` for [.pull-out-quote](https://github.com/localgovdrupal/localgov_theme/blob/ad1d38b2a9d51716620c42fad10e246119a72e22/assets/scss/lib/partials/_page-builder.scss#L185), an alternative would be to extend this selector to cover `blockquote`