### PR TITLE
Remove redundant type attribute

### DIFF
--- a/templates/form_element/input--submit.html.twig
+++ b/templates/form_element/input--submit.html.twig
@@ -11,7 +11,7 @@
  */
 #}
 
-<button type="submit" {{ attributes.addClass(['btn', 'btn-primary', 'btn-sm', 'mt-2']) }}>
+<button{{ attributes.addClass(['btn', 'btn-primary', 'btn-sm', 'mt-2']) }}>
   <span class="fa fa-chevron-right"></span>
   <span>{{ attributes.value }}</span>
 </button>


### PR DESCRIPTION
Closes #175:

- Removes redundant type attribute which causes HTML validation errors.