### PR TITLE
Form element description position

### DIFF
--- a/templates/form_element/form-element.html.twig
+++ b/templates/form_element/form-element.html.twig
@@ -44,12 +44,26 @@
  * @see template_preprocess_form_element()
  */
 #}
+{%
+  set description_classes = [
+    'description',
+    description_display == 'invisible' ? 'visually-hidden',
+    'form-text',
+    'small',
+    'text-muted',
+  ]
+%}
 <div {{ attributes }}>
   {% if label_display in ['before', 'invisible'] %}
     {{ label }}
   {% endif %}
   {% if prefix is not empty %}
     <span class="field-prefix">{{ prefix }}</span>
+  {% endif %}
+  {% if description_display == 'before' and description.content %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
   {% endif %}
   {{ children }}
   {% if suffix is not empty %}
@@ -63,7 +77,9 @@
       {{ errors }}
     </div>
   {% endif %}
-  {% if description.content %}
-    <small class="form-text text-muted">{{ description.content }}</small>
+  {% if description_display in ['after', 'invisible'] and description.content %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
   {% endif %}
 </div>


### PR DESCRIPTION
Form element description can appear both before and after the input item.  At the
moment, only the *after* position is supported.  Fixed now.

@see https://git.drupalcode.org/project/drupal/-/blob/9.2.x/core/modules/system/templates/form-element.html.twig