### PR TITLE
Bug fix: Nonexistent base_path variable in html.html.twig

### DIFF
--- a/localgov_theme.theme
+++ b/localgov_theme.theme
@@ -7,8 +7,24 @@
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Template\Attribute;
+use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_preprocess().
+ *
+ * Adds these theme variables:
+ * - localgov_front_page: Front page path or URL.  May contain language prefix.
+ * - localgov_front_page_default_lang: Same as above without any language
+ *   prefix.  Useful for building asset paths.
+ *
+ * These variables become available in *all* templates.
+ */
+function localgov_theme_preprocess(&$variables) {
+  $variables['localgov_front_page'] = Url::fromRoute('<front>')->toString();
+  $variables['localgov_front_page_default_lang'] = Url::fromRoute('<front>')->setOption('language', Drupal::service('language.default')->get())->toString();
+}
 
 /**
  * Implements hook_preprocess_HOOK().

--- a/templates/system/html.html.twig
+++ b/templates/system/html.html.twig
@@ -32,22 +32,22 @@
     <title>{{ head_title|safe_join(' | ') }}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/{{ base_path ~ directory }}/assets/img/favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/{{ base_path ~ directory }}/assets/img/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/{{ base_path ~ directory }}/assets/img/favicon/favicon-16x16.png">
-    <link rel="manifest" href="/{{ base_path ~ directory }}/assets/img/favicon/site.webmanifest">
-    <link rel="shortcut icon" href="/{{ base_path ~ directory }}/assets/img/favicon/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ localgov_front_page_default_lang ~ directory }}/assets/img/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ localgov_front_page_default_lang ~ directory }}/assets/img/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ localgov_front_page_default_lang ~ directory }}/assets/img/favicon/favicon-16x16.png">
+    <link rel="manifest" href="{{ localgov_front_page_default_lang ~ directory }}/assets/img/favicon/site.webmanifest">
+    <link rel="shortcut icon" href="{{ localgov_front_page_default_lang ~ directory }}/assets/img/favicon/favicon.ico">
     <meta name="msapplication-TileColor" content="#000000">
-    <meta name="msapplication-config" content="/{{ base_path ~ directory }}/assets/img/favicon/browserconfig.xml">
-    <meta name="msapplication-TileImage" content="/{{ base_path ~ directory }}/assets/img/favicon/mstile-144x144.png">
-    <meta name="msapplication-TileImage" content="/{{ base_path ~ directory }}/assets/img/favicon/mstile-310x310.png">
+    <meta name="msapplication-config" content="{{ localgov_front_page_default_lang ~ directory }}/assets/img/favicon/browserconfig.xml">
+    <meta name="msapplication-TileImage" content="{{ localgov_front_page_default_lang ~ directory }}/assets/img/favicon/mstile-144x144.png">
+    <meta name="msapplication-TileImage" content="{{ localgov_front_page_default_lang ~ directory }}/assets/img/favicon/mstile-310x310.png">
     <meta name="theme-color" content="#000000">
 
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
 
     <!--[if lt IE 9 ]>
-    <script src="{{ base_path ~ directory }}/assets/js/respond.min.js"></script>
+    <script src="{{ localgov_front_page_default_lang ~ directory }}/assets/js/respond.min.js"></script>
     <![endif]-->
   </head>
 
@@ -59,7 +59,7 @@
 
     <!-- flexbox polyfill -->
     <!--[if lte IE 9 ]>
-    <script src="/{{ base_path ~ directory }}/assets/js/flexibility.js"></script>
+    <script src="{{ localgov_front_page_default_lang ~ directory }}/assets/js/flexibility.js"></script>
     <script type='text/javascript'>
     window.onload=function(){
       flexibility(document.body);


### PR DESCRIPTION
The ```base_path``` Twig variable used in [html.html.twig](https://github.com/localgovdrupal/localgov_theme/blob/cbb5fa37e1d2f29d793a51f4880f64d7824ae036/templates/system/html.html.twig#L35) doesn't actually exist.  This fix adds the ```localgov_front_page_default_lang``` variable as a replacement.  As an added bonus, ```localgov_front_page_default_lang``` can be modified through [PathProcessors](https://git.drupalcode.org/project/drupal/-/blob/9.2.x/core/lib/Drupal/Core/PathProcessor/OutboundPathProcessorInterface.php) plugins.